### PR TITLE
Pass 'MethodNotAllowed'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ script:
 - java -jar fitnesse.jar -c  "HttpTestSuite.ResponseTestSuite.SimplePut?test&format=text"
 - java -jar fitnesse.jar -c  "HttpTestSuite.ResponseTestSuite.FourEightTeen?test&format=text"
 - java -jar fitnesse.jar -c  "HttpTestSuite.ResponseTestSuite.SimpleHead?test&format=text"
+- java -jar fitnesse.jar -c  "HttpTestSuite.ResponseTestSuite.MethodNotAllowed?test&format=text"

--- a/build_and_test.sh
+++ b/build_and_test.sh
@@ -6,4 +6,5 @@ java -jar fitnesse.jar -c  "HttpTestSuite.ResponseTestSuite.FourOhFour?test&form
 java -jar fitnesse.jar -c  "HttpTestSuite.ResponseTestSuite.SimplePut?test&format=text"
 java -jar fitnesse.jar -c  "HttpTestSuite.ResponseTestSuite.SimpleHead?test&format=text"
 java -jar fitnesse.jar -c  "HttpTestSuite.ResponseTestSuite.FourEightTeen?test&format=text"
+java -jar fitnesse.jar -c  "HttpTestSuite.ResponseTestSuite.MethodNotAllowed?test&format=text"
 cd -

--- a/src/main/java/HttpServer/SynchronousListener.java
+++ b/src/main/java/HttpServer/SynchronousListener.java
@@ -29,6 +29,9 @@ public class SynchronousListener {
         });
         router.defineRoute("/coffee", "GET", coffeeHandler);
         router.defineRoute("/", "HEAD", new Response().setStatus(200));
+        router.defineRoute("/file1", "GET", new Response().setStatus(200));
+        router.defineRoute("/text-file.txt", "GET", new Response().setStatus(200));
+
     }
 
 

--- a/src/test/java/HttpServer/CobSpecUnitTests.java
+++ b/src/test/java/HttpServer/CobSpecUnitTests.java
@@ -26,6 +26,8 @@ public class CobSpecUnitTests {
         });
         router.defineRoute("/coffee", "GET", coffeeHandler);
         router.defineRoute("/", "HEAD", new Response().setStatus(200));
+        router.defineRoute("/file1", "GET", new Response().setStatus(200));
+        router.defineRoute("/text-file.txt", "GET", new Response().setStatus(200));
     }
 
     @Test


### PR DESCRIPTION
Routes necessary to passing cob_spec tests are created in `SynchronousListener` to match `CobSpecUnitTests` until I have a better place for them. These resources are simulated (i.e., added directly to the Router) until next iteration.