### PR TITLE
Prevent NPE when querying OPTIONS of non-existent resource

### DIFF
--- a/src/main/java/HttpServer/core/router/Router.java
+++ b/src/main/java/HttpServer/core/router/Router.java
@@ -39,6 +39,11 @@ public class Router {
 
     private Response respondToOptionsQuery(Request request) {
         Response response = new Response();
+        String uri = request.getUri();
+        if (uri != "*" && !getDefinedUris().contains(uri)) {
+            response.setStatus(404);
+            return response;
+        }
         response.setStatus(200);
         ArrayList<String> allowedMethods = getDefinedMethods(request.getUri());
         response.setHeader("Allow", String.join(",", allowedMethods));

--- a/src/test/java/HttpServer/core/router/RouterTest.java
+++ b/src/test/java/HttpServer/core/router/RouterTest.java
@@ -207,6 +207,18 @@ public class RouterTest {
         assertThat(allowedMethods, containsString("PUT"));
     }
 
+    @Test
+    public void it404sOptionRequestsToNonExistentResources() {
+        // Fixing bug: OPTIONS /non-existent crashes the server with an NPE
+        Router router = new Router();
+        Request request = new Request();
+        request.setMethod("OPTIONS");
+        request.setUri("/absent-resource");
+
+        Response response = router.route(request);
+        assertEquals(404, response.getStatus());
+    }
+
     @Ignore
     public void itCanHaveFileRoutesDefined() {
         FileRouteDefiner definer = new FileRouteDefiner("./cob_spec/public", new Router());


### PR DESCRIPTION
New behavior: respond with 404.