### PR TITLE
Media types pending image content

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,12 +23,12 @@ end
 
 task :run_next => :build do
   features_pending = [
+    "MediaTypes",
     "BasicAuth",
     "CookieData",
     "DirectoryLinks",
     "DirectoryListing",
     "ImageContent",
-    "MediaTypes",
     "PartialContent",
     "PatchWithEtag",
     "PostGetPutGetDeleteGet"]

--- a/src/main/java/HttpServer/core/resource/DirectoryHandler.java
+++ b/src/main/java/HttpServer/core/resource/DirectoryHandler.java
@@ -2,7 +2,6 @@ package HttpServer.core.resource;
 
 import HttpServer.core.request.Request;
 import HttpServer.core.response.Response;
-import HttpServer.core.router.Router;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,8 +14,10 @@ import java.util.stream.Stream;
 public class DirectoryHandler implements Handler {
 
     private final File directory;
+    private final MediaTypeChecker typeChecker;
 
     public DirectoryHandler(String directoryPath) {
+        this.typeChecker = new MediaTypeChecker();
         this.directory = new File(directoryPath);
     }
 
@@ -25,18 +26,19 @@ public class DirectoryHandler implements Handler {
         File file = getFile(request.getUriString());
         Response response = new Response();
         if (file.exists()) {
-            respondWithFileContent(file, response);
+            respondWithFileData(file, response);
         } else {
             response.setStatus(404);
         }
         return response;
     }
 
-    private void respondWithFileContent(File file, Response response) {
+    private void respondWithFileData(File file, Response response) {
         response.setStatus(200);
         try {
             StringBuilder content = getFileContent(file);
             response.setBody(content.toString().trim());
+            response.setHeader("Content-Type", typeChecker.typeFile(file));
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/HttpServer/core/resource/MediaTypeChecker.java
+++ b/src/main/java/HttpServer/core/resource/MediaTypeChecker.java
@@ -1,0 +1,42 @@
+package HttpServer.core.resource;
+
+import java.io.File;
+import java.util.HashMap;
+
+public class MediaTypeChecker {
+    private HashMap<String, String> types;
+
+    public MediaTypeChecker() {
+        this.types = new HashMap<String, String>();
+        types.put("jpeg", "image/jpeg");
+        types.put("png", "image/png");
+        types.put("gif", "image/gif");
+        types.put("txt", "text/plain");
+    }
+
+    public String typeExtension(String extension) {
+        String type = types.get(extension);
+        if (type == null) {
+            return "application/octet-stream";
+        } else {
+            return type;
+        }
+    }
+
+    public String typeFilename(String filename) {
+        String separator = "\\.";
+        String[] tokens = filename.split(separator);
+        String extension;
+        if (tokens.length == 1) {
+            extension = "";
+        } else {
+            extension = tokens[tokens.length-1];
+        }
+        return typeExtension(extension);
+    }
+
+    public String typeFile(File file) {
+        String filename = file.getName();
+        return typeFilename(filename);
+    }
+}

--- a/src/test/java/HttpServer/core/resource/DirectoryHandlerTest.java
+++ b/src/test/java/HttpServer/core/resource/DirectoryHandlerTest.java
@@ -15,10 +15,15 @@ import static org.junit.Assert.assertEquals;
 public class DirectoryHandlerTest {
 
     private DirectoryHandler directoryHandler;
+    private Request fileRequest;
 
     @Before
     public void setup() {
         this.directoryHandler = new DirectoryHandler("cob_spec/public");
+        Request fileRequest = new Request();
+        fileRequest.setUri("/file1");
+        fileRequest.setMethod("GET");
+        this.fileRequest = fileRequest;
     }
 
     @Test
@@ -40,29 +45,20 @@ public class DirectoryHandlerTest {
 
     @Test
     public void itIsOkIfFileExists() {
-        Request request = new Request();
-        request.setUri("/file1");
-        request.setMethod("GET");
-        Response response = directoryHandler.respond(request);
+        Response response = directoryHandler.respond(fileRequest);
         assertEquals(200, response.getStatus());
     }
 
     @Test
     public void itRespondsToGetWithBodySetToContent() {
-        Request request = new Request();
-        request.setUri("/file1");
-        request.setMethod("GET");
-        Response response = directoryHandler.respond(request);
+        Response response = directoryHandler.respond(fileRequest);
         assertEquals("file1 contents", response.getBody());
     }
 
     @Test
-    public void itsFilesDoMakeItThroughTheRouterRight() {
-        Request request = new Request("/file1", "GET");
-        Router router = new Router();
-        router.defineRoute("/file1", "GET", directoryHandler);
-        Response response = router.route(request);
-        assertEquals(200, response.getStatus());
-        assertEquals("file1 contents", response.getBody());
+    public void itRespondsWithContentTypeSet() {
+        Response response = directoryHandler.respond(fileRequest);
+        assertEquals("application/octet-stream", response.getHeader("Content-Type"));
     }
+
 }

--- a/src/test/java/HttpServer/core/resource/MediaTypeCheckerTest.java
+++ b/src/test/java/HttpServer/core/resource/MediaTypeCheckerTest.java
@@ -1,0 +1,47 @@
+package HttpServer.core.resource;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+public class MediaTypeCheckerTest {
+    private MediaTypeChecker checker;
+
+    // WARNING: This implementation of a media type checker depends on file extensions being accurate. Files without
+    // file extensions will be typed "application/octet-stream", indicating the body contains arbitrary binary data.
+    //
+    // Reference: https://www.iana.org/assignments/media-types/application/octet-stream
+
+    @Before
+    public void setup() {
+        this.checker = new MediaTypeChecker();
+    }
+
+    @Test
+    public void itMapsFileExtensionsToContentTypes() {
+        assertEquals("image/jpeg", checker.typeExtension("jpeg"));
+        assertEquals("image/png", checker.typeExtension("png"));
+        assertEquals("image/gif", checker.typeExtension("gif"));
+        assertEquals("text/plain", checker.typeExtension("txt"));
+        assertEquals("application/octet-stream", checker.typeExtension("exe"));
+    }
+
+    @Test
+    public void itMapsFilenamesToTheirStatedContentType() {
+        assertEquals("image/jpeg", checker.typeFilename("cat-pix.jpeg"));
+    }
+
+    @Test
+    public void itTypesUnstatedContentTypesAsOctet() {
+        assertEquals("application/octet-stream", checker.typeFilename("verysafefile"));
+    }
+
+    @Test
+    public void itTypesFiles() {
+        File file = new File("cob_spec/public/file1");
+        assertEquals("application/octet-stream", checker.typeFile(file));
+    }
+}


### PR DESCRIPTION
The byte-encoding problem Tyler anticipated keeps this feature from passing tests, because my server will throw an exception when getting image content. The server log is showing the correct behavior for text files, so I believe I'll be able to add this feature to the passing suite once ImageContent is finished.